### PR TITLE
fix:  Fix vue template variable type output format error

### DIFF
--- a/examples/semi-d2c-plugin-vue/src/modifyProps.ts
+++ b/examples/semi-d2c-plugin-vue/src/modifyProps.ts
@@ -1,6 +1,14 @@
 import { PluginHooks, TreeNode } from '@douyinfe/semi-d2c-typings';
 import { omit } from 'lodash';
 
+function transformJsonString(jsonStr: string): string {
+  // 第一步：对单引号添加转义符
+  let escapedSingleQuotes = jsonStr.replace(/'/g, "\\'");
+  // 第二步：将双引号替换为单引号
+  let result = escapedSingleQuotes.replace(/"/g, "'");
+  return result;
+}
+
 const slotToTemplate = (
   node: TreeNode,
   options: Parameters<TreeNode['toTemplate']>[1],
@@ -49,7 +57,7 @@ const modifyProps: PluginHooks['modifyProps'] = (args) => {
             props[':class'] = value;
           }
         } else {
-          props[`:${key}`] = value;
+          props[`:${key}`] = typeof value === 'object' ? transformJsonString(JSON.stringify(value)) : `${value}`;
           delete props[key];
         }
         break;


### PR DESCRIPTION
bug 复现方法： 官方设计稿  Semi D2C Playground (Community) ，layer名称为 Complex Form
生成结果 属性变量还是react jsx 格式，没有经过处理
![image](https://github.com/user-attachments/assets/a77099f5-2d1a-4ed4-8bf9-0e3de5a82e1a)
修复后为：
![image](https://github.com/user-attachments/assets/745a1a22-3417-4020-a49c-878ed9fc1829)


